### PR TITLE
Restore deleted aggregator-configmap.yaml

### DIFF
--- a/stable/search-prod/templates/aggregator-configmap.yaml
+++ b/stable/search-prod/templates/aggregator-configmap.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2020 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: search-aggregator
+  labels:
+    config: acm-proxyserver
+data:
+  service: "{{ .Release.Namespace }}/search-aggregator"
+  port: "3010"
+  path: "/aggregator/clusters/"
+  sub-resource: "/sync"
+  use-id: "true"
+  secret: "{{ .Release.Namespace }}/search-aggregator-secrets"


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/11742

### Changes:
Restoring file `aggregator-configmap.yaml`. It was accidentally deleted by the previous PR.