### PR TITLE
Instrospect namespace in search-api deployment

### DIFF
--- a/stable/search-prod/templates/api-deployment.yaml
+++ b/stable/search-prod/templates/api-deployment.yaml
@@ -79,6 +79,10 @@ spec:
             secretKeyRef:
               name: redisgraph-user-secret
               key: redispwd
+        - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
         ports:
         - containerPort: 4010
           protocol: TCP

--- a/stable/search-prod/templates/api-deployment.yaml
+++ b/stable/search-prod/templates/api-deployment.yaml
@@ -80,9 +80,9 @@ spec:
               name: redisgraph-user-secret
               key: redispwd
         - name: POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         ports:
         - containerPort: 4010
           protocol: TCP


### PR DESCRIPTION
Issue: open-cluster-management/backlog#11303

### Changes
- Pass the pod namespace as an environment variable.
- Needed for https://github.com/open-cluster-management/search-api/pull/111