### PR TITLE
grant delete pod permission for operator

### DIFF
--- a/stable/search-prod/templates/operator-role.yaml
+++ b/stable/search-prod/templates/operator-role.yaml
@@ -27,6 +27,7 @@ rules:
   - create
   - update
   - watch
+  - delete
 - apiGroups:
   - ""
   resources:


### PR DESCRIPTION
Related to https://github.com/open-cluster-management/search-operator/pull/57. Granting delete pod permission to search-operator so that search collector pod can be restarted.