### PR TITLE
API needs permission to read operator status

### DIFF
--- a/stable/search-prod/templates/api-role.yaml
+++ b/stable/search-prod/templates/api-role.yaml
@@ -25,3 +25,7 @@ rules:
   resources: ["tokenreviews"]
   verbs:
   - create
+- apiGroups: ["search.open-cluster-management.io"]
+  resources: ["searchoperators"]
+  verbs:
+  - get


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/11303

### Changes
- The search-api needs permissions to read the status from the search operator.