### PR TITLE
Aggregator should tolerate having no available replicas

### DIFF
--- a/stable/search-prod/templates/aggregator-deployment.yaml
+++ b/stable/search-prod/templates/aggregator-deployment.yaml
@@ -22,6 +22,9 @@ spec:
       component: "search-aggregator"
       release: {{ .Release.Name }}
       heritage: {{ .Release.Service }}
+  strategy:
+    rollingUpdate:
+      maxUnavailable: 100%
   template:
     metadata:
       labels:


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/11303
 
### Changes
When Redisgraph is disabled, the aggregator deployment doesn't have any available replicas.  With this change, this condition won't be interpreted as an error by the ACM install. 