### PR TITLE
Use release namespace to avoid errors in non-default namespace installs

### DIFF
--- a/stable/search-prod/templates/aggregator-deployment.yaml
+++ b/stable/search-prod/templates/aggregator-deployment.yaml
@@ -70,7 +70,7 @@ spec:
           readOnlyRootFilesystem: true
         env:
         - name: REDIS_HOST
-          value: '{{ template "search.fullname" . }}-search-redisgraph.{{ .Values.org }}.svc'
+          value: '{{ template "search.fullname" . }}-search-redisgraph.{{ .Release.Namespace }}.svc'
         - name: REDIS_SSH_PORT
           value: "6380"
         - name: REDIS_PASSWORD

--- a/stable/search-prod/templates/api-deployment.yaml
+++ b/stable/search-prod/templates/api-deployment.yaml
@@ -73,7 +73,7 @@ spec:
         - name: PLATFORM_IDENTITY_PROVIDER_URL
           value: {{ .Values.global.cfcRouterUrl }}/idprovider
         - name: redisSSLEndpoint
-          value: '{{ template "search.fullname" . }}-search-redisgraph.{{ .Values.org }}.svc:6380'
+          value: '{{ template "search.fullname" . }}-search-redisgraph.{{ .Release.Namespace }}.svc:6380'
         - name: redisPassword
           valueFrom:
             secretKeyRef:

--- a/stable/search-prod/templates/collector-deployment.yaml
+++ b/stable/search-prod/templates/collector-deployment.yaml
@@ -74,7 +74,7 @@ spec:
         - name: CLUSTER_NAME
           value: local-cluster
         - name: AGGREGATOR_URL
-          value: 'https://search-aggregator.{{ .Values.org }}.svc:3010'
+          value: 'https://search-aggregator.{{ .Release.Namespace }}.svc:3010'
         resources:
 {{ toYaml .Values.search.collector.resources | indent 10 }}
         livenessProbe:


### PR DESCRIPTION
Use release.namespace to update variables instead of defaulting to open-cluster-management.
For issues: https://github.com/open-cluster-management/backlog/issues/12177
https://github.com/open-cluster-management/backlog/issues/12175
https://github.com/open-cluster-management/backlog/issues/12130