### PR TITLE
Update aggregator permissions for klusterletaddonconfigs

### DIFF
--- a/stable/search-prod/templates/aggregator-role.yaml
+++ b/stable/search-prod/templates/aggregator-role.yaml
@@ -18,3 +18,9 @@ rules:
   - get
   - list
   - watch
+- apiGroups: ['agent.open-cluster-management.io']
+  resources: ["klusterletaddonconfigs"]
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Related Issue: open-cluster-management/backlog#12024
Related PR: https://github.com/open-cluster-management/search-aggregator/pull/125

## Change
Update the aggregator role to allow reading and watching klusterletaddonconfigs.agent.open-cluster-management.io