### PR TITLE
[2.2] add Release_Name env to operator deployment

### DIFF
--- a/stable/search-prod/templates/operator-deployment.yaml
+++ b/stable/search-prod/templates/operator-deployment.yaml
@@ -4,6 +4,12 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: search-operator
+  labels:
+    app: {{ template "search.name" . }}
+    chart: {{ template "search.chart" . }}
+    component: "search-operator"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   replicas: 1
   selector:
@@ -14,6 +20,10 @@ spec:
       labels:
         name: search-operator
         ocm-antiaffinity-selector: "searchoperator"
+        app: {{ template "search.name" . }}
+        release: {{ .Release.Name }}
+        chart: {{ template "search.chart" . }}
+        heritage: {{ .Release.Service }}
     spec:
       serviceAccountName: search-operator
       tolerations:
@@ -33,6 +43,8 @@ spec:
         image: {{ .Values.global.imageOverrides.search_operator }}
         imagePullPolicy: {{ .Values.global.pullPolicy }}
         env:
+          - name: RELEASE_NAME
+            value: {{ .Release.Name }}
           - name: WATCH_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
For open-cluster-management/backlog#12299
Add labels to be consistent with other search components