### PR TITLE
cd into new repo name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script: 
         - git clone --single-branch --branch master https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multicloudhub-repo.git
-        - cd multicloudhub-repo
+        - cd multiclusterhub-repo
         - ./cicd-scripts/chartAutomation.sh search-chart
     - stage: release-ff
       name: "Push commits to current release branch"


### PR DESCRIPTION
https://travis-ci.com/github/open-cluster-management/search-chart/jobs/515443905 Merge to release branch failed with error. PR to fix

    git clone --single-branch --branch master https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multicloudhub-repo.git
    Cloning into 'multicloudhub-repo'...
    warning: Could not find remote branch master to clone.
    fatal: Remote branch master not found in upstream origin
    The command "git clone --single-branch --branch master https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multicloudhub-repo.git" exited with 128.
    0.00s$ cd multicloudhub-repo
    /home/travis/.travis/functions: line 109: cd: multicloudhub-repo: No such file or directory
    The command "cd multicloudhub-repo" exited with 1.
    0.00s$ ./cicd-scripts/chartAutomation.sh search-chart
    /home/travis/.travis/functions: line 109: ./cicd-scripts/chartAutomation.sh: No such file or directory
    The command "./cicd-scripts/chartAutomation.sh search-chart" exited with 127.
