### PR TITLE
[release-2.2] Point to multiclusterhub-repo release-2.2 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       name: "Auto trigger mch-repo"
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script: 
-        - git clone --single-branch --branch main https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multicloudhub-repo.git
+        - git clone --single-branch --branch main https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multiclusterhub-repo.git
         - cd multiclusterhub-repo
         - ./cicd-scripts/chartAutomation.sh search-chart
     - stage: release-ff

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
       name: "Auto trigger mch-repo"
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script: 
-        - git clone --single-branch --branch main https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multiclusterhub-repo.git
+        - git clone --single-branch --branch release-2.2 https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multiclusterhub-repo.git
         - cd multiclusterhub-repo
         - ./cicd-scripts/chartAutomation.sh search-chart
     - stage: release-ff

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ stages:
 
 branches:
   only:
-    - master
+    - main
     - /^release-[0-9]+\..*$/
 
 jobs:
@@ -33,12 +33,12 @@ jobs:
       name: "Auto trigger mch-repo"
       if: type = push AND branch =~ /^release-[0-9]+\..*$/
       script: 
-        - git clone --single-branch --branch master https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multicloudhub-repo.git
+        - git clone --single-branch --branch main https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multicloudhub-repo.git
         - cd multiclusterhub-repo
         - ./cicd-scripts/chartAutomation.sh search-chart
     - stage: release-ff
       name: "Push commits to current release branch"
-      if: type = push AND branch =~ /^master$/
+      if: type = push AND branch =~ /^main$/
       script:
         - make
         - make release-ff


### PR DESCRIPTION
To fix error - updating branch name to main.

> $ git clone --single-branch --branch master https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multicloudhub-repo.git
> Cloning into 'multicloudhub-repo'...
> warning: Could not find remote branch master to clone.
> fatal: Remote branch master not found in upstream origin
> The command "git clone --single-branch --branch master https://${MCH_REPO_BOT_TOKEN}@github.com/open-cluster-management/multicloudhub-repo.git" exited with 128.
> 0.00s$ cd multiclusterhub-repo
> /home/travis/.travis/functions: line 109: cd: multiclusterhub-repo: No such file or directory
> The command "cd multiclusterhub-repo" exited with 1.
> 0.00s$ ./cicd-scripts/chartAutomation.sh search-chart
> /home/travis/.travis/functions: line 109: ./cicd-scripts/chartAutomation.sh: No such file or directory
> The command "./cicd-scripts/chartAutomation.sh search-chart" exited with 127.