### PR TITLE
Rename certificates to fix upgrade to 2.3

### DIFF
--- a/stable/search-prod/templates/aggregator-configmap.yaml
+++ b/stable/search-prod/templates/aggregator-configmap.yaml
@@ -13,5 +13,5 @@ data:
   path: "/aggregator/clusters/"
   sub-resource: "/sync"
   use-id: "true"
-  secret: "{{ .Release.Namespace }}/search-aggregator-secrets"
+  secret: "{{ .Release.Namespace }}/search-aggregator-certs"
   caConfigMap: search-ca-crt

--- a/stable/search-prod/templates/aggregator-deployment.yaml
+++ b/stable/search-prod/templates/aggregator-deployment.yaml
@@ -112,7 +112,7 @@ spec:
       volumes:
       - name: search-certs
         secret:
-          secretName: search-aggregator-secrets
+          secretName: search-aggregator-certs
       - name: redis-graph-certs
         configMap:
           name: search-ca-crt

--- a/stable/search-prod/templates/aggregator-service.yaml
+++ b/stable/search-prod/templates/aggregator-service.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: search-aggregator-secrets
+    service.beta.openshift.io/serving-cert-secret-name: search-aggregator-certs
   name: search-aggregator
   labels:
     app: {{ template "search.name" . }}

--- a/stable/search-prod/templates/api-deployment.yaml
+++ b/stable/search-prod/templates/api-deployment.yaml
@@ -128,7 +128,7 @@ spec:
       volumes:
       - name: search-api-certs
         secret:
-          secretName: {{ .Release.Name }}-search-api-secrets
+          secretName: search-api-certs
           items:
           - key: tls.crt
             path: searchapi.crt

--- a/stable/search-prod/templates/api-service.yaml
+++ b/stable/search-prod/templates/api-service.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: {{ .Release.Name }}-search-api-secrets
+    service.beta.openshift.io/serving-cert-secret-name: search-api-certs
   name: search-search-api
   labels:
     app: {{ .Values.search.name }}

--- a/stable/search-prod/templates/collector-deployment.yaml
+++ b/stable/search-prod/templates/collector-deployment.yaml
@@ -99,7 +99,7 @@ spec:
       volumes:
       - name: search-aggregator-certs
         secret:
-          secretName: search-aggregator-secrets
+          secretName: search-aggregator-certs
       hostIPC: false
       hostNetwork: false
       hostPID: false

--- a/stable/search-prod/templates/redisgraph-service.yaml
+++ b/stable/search-prod/templates/redisgraph-service.yaml
@@ -8,7 +8,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.beta.openshift.io/serving-cert-secret-name: search-redisgraph-secrets
+    service.beta.openshift.io/serving-cert-secret-name: search-redisgraph-certs
   name: {{ template "search.fullname" . }}-search-redisgraph
   labels:
     app: {{ template "search.name" . }}


### PR DESCRIPTION
Issue: https://github.com/open-cluster-management/backlog/issues/13930

### Changes
After an upgrade from 2.2.x to 2.3 we stop using cert manager and a new certificate is generated using service.beta.openshift.io.  This change renames the certificates to avoid sync issues after the upgrade.

MUST MERGE TOGETHER WITH https://github.com/open-cluster-management/search-operator/pull/70