### PR TITLE
[2.4 WIP] Remove console-api env var

### DIFF
--- a/stable/search-prod/templates/ui-deployment.yaml
+++ b/stable/search-prod/templates/ui-deployment.yaml
@@ -66,8 +66,6 @@ spec:
           value: https://kubernetes.default.svc:443
         - name: SEARCH_API_URL
           value: https://search-search-api:4010/searchapi
-        - name: CONSOLE_API_URL
-          value: https://console-api:4000/hcmuiapi
         - name: FRONTEND_URL
           value: "https://multicloud-console.{{ .Values.ocpingress }}/search/"
         - name: OAUTH2_REDIRECT_URL


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

Related issue: https://github.com/open-cluster-management/backlog/issues/9480

We are migrating the console-api queries to search-api. We no longer need the console-api env var definition.