### PR TITLE
grant get lease to operator

### DIFF
--- a/stable/search-prod/templates/operator-role.yaml
+++ b/stable/search-prod/templates/operator-role.yaml
@@ -101,3 +101,6 @@ rules:
   - get
   - list
   - watch
+  - create
+  - update
+  - patch

--- a/stable/search-prod/templates/operator-role.yaml
+++ b/stable/search-prod/templates/operator-role.yaml
@@ -93,3 +93,11 @@ rules:
   - securitycontextconstraints
   verbs:
   - use
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Signed-off-by: Sherin Varughese <shvarugh@redhat.com>

While updating deps to latest for search-operator in https://github.com/open-cluster-management/search-operator/pull/87, noticed this error in search-operator logs

> ➜  oc logs search-operator-654cb9ddfc-99wjj  
> I0922 21:22:42.924203       1 request.go:665] Waited for 1.028430026s due to client-side throttling, not priority and fairness, request: GET:https://172.30.0.1:443/apis/internal.open-cluster-management.io/v1beta1?timeout=32s
> 2021-09-22T21:22:46.629Z	INFO	controller-runtime.metrics	metrics server is starting to listen	{"addr": ":8080"}
> 2021-09-22T21:22:46.629Z	INFO	setup	starting manager
> I0922 21:22:46.630077       1 leaderelection.go:248] attempting to acquire leader lease open-cluster-management/c2dd32d7...
> 2021-09-22T21:22:46.630Z	INFO	starting metrics server	{"path": "/metrics"}
> E0922 21:22:46.639799       1 leaderelection.go:330] error retrieving resource lock open-cluster-management/c2dd32d7: leases.coordination.k8s.io "c2dd32d7" is forbidden: User "system:serviceaccount:open-cluster-management:search-operator" cannot get resource "leases" in API group "coordination.k8s.io" in the namespace "open-cluster-management"

To avoid this, adding this privilege to operator role.